### PR TITLE
Feat SCRUM-72: 작업률 지체로 인한 Creat PR 기능 제거

### DIFF
--- a/.github/workflows/create-jira-close-pr.yml
+++ b/.github/workflows/create-jira-close-pr.yml
@@ -21,36 +21,36 @@ jobs:
       - name: Run Build
         run: npm run build
 
-  create-pr:
-    needs: run-test
-    name: Create PR
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Codes
-        uses: actions/checkout@v4
+  # create-pr:
+  #   needs: run-test
+  #   name: Create PR
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download Codes
+  #       uses: actions/checkout@v4
 
-      # 브랜치 이름에서 Jira 이슈 번호 추출 (예: feat/#SCURM-1-login)
-      - name: Create PR Title
-        id: pr-title
-        run: |
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          JIRA_ISSUE=$(echo $BRANCH_NAME | grep -oE '#[A-Z]+-[0-9]+' | sed 's/^#//' || echo "")
-          echo "pr_title_content=$JIRA_ISSUE #close $BRANCH_NAME branch" >> $GITHUB_OUTPUT
+  #     # 브랜치 이름에서 Jira 이슈 번호 추출 (예: feat/#SCURM-1-login)
+  #     - name: Create PR Title
+  #       id: pr-title
+  #       run: |
+  #         BRANCH_NAME=${GITHUB_REF#refs/heads/}
+  #         JIRA_ISSUE=$(echo $BRANCH_NAME | grep -oE '#[A-Z]+-[0-9]+' | sed 's/^#//' || echo "")
+  #         echo "pr_title_content=$JIRA_ISSUE #close $BRANCH_NAME branch" >> $GITHUB_OUTPUT
 
-      - name: Create PR Template
-        id: pr-template
-        run: |
-          PR_BODY=$(cat .github/PULL_REQUEST_TEMPLATE.md)
-          ls -a
-          echo "pr_body<<EOF" >> $GITHUB_OUTPUT
-          echo "$PR_BODY" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+  #     - name: Create PR Template
+  #       id: pr-template
+  #       run: |
+  #         PR_BODY=$(cat .github/PULL_REQUEST_TEMPLATE.md)
+  #         ls -a
+  #         echo "pr_body<<EOF" >> $GITHUB_OUTPUT
+  #         echo "$PR_BODY" >> $GITHUB_OUTPUT
+  #         echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Create PR
-        uses: peter-evans/create-pull-request@v7
-        with:
-          title: "${{ steps.pr-title.outputs.pr_title_content }}"
-          body: ${{ steps.pr-template.outputs.pr_body }}
-          base: develop
-          branch: ${{github.ref}}
-          token: ${{ secrets.ACCESS_TOKEN_FOR_CI }}
+  #     - name: Create PR
+  #       uses: peter-evans/create-pull-request@v7
+  #       with:
+  #         title: "${{ steps.pr-title.outputs.pr_title_content }}"
+  #         body: ${{ steps.pr-template.outputs.pr_body }}
+  #         base: develop
+  #         branch: ${{github.ref}}
+  #         token: ${{ secrets.ACCESS_TOKEN_FOR_CI }}


### PR DESCRIPTION
## Summary by CodeRabbit

- **Chores**
	- GitHub Actions 워크플로우에서 `create-pr` 작업을 비활성화했습니다.
	- 기존 테스트 작업은 계속 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->