### PR TITLE
hotFix: verifyToken의 url 경로 문제로 인증 페이지에 접근 못하는 문제 해결

### DIFF
--- a/app/apis/server/tokenApi.ts
+++ b/app/apis/server/tokenApi.ts
@@ -4,7 +4,7 @@ export const verifyToken = async (
   token: {name: string; value: string} | undefined,
 ): Promise<boolean> => {
   try {
-    await serverInstance.get({path: '/auth/user', token: token?.value});
+    await serverInstance.get({path: '/auths/user', token: token?.value});
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## 작업 내용
- verifyToken의 url 경로 문제로 인증 페이지에 접근 못하는 문제 해결