### PR TITLE
fix: 필터 초기화 후 UI 동기화 문제 해결 및 중복 모임 생성 방지

### DIFF
--- a/app/components/common/filter/dropdown.tsx
+++ b/app/components/common/filter/dropdown.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 
-import {Dispatch, SetStateAction, useState} from 'react';
+import {Dispatch, SetStateAction, useEffect, useState} from 'react';
 
 import {DefaultValue, SelectedItem} from '../../../types/dropDown.types';
 import {GetReviewsProps} from '../../../types/reviews/reviewsApi.types';
@@ -23,6 +23,28 @@ export function Dropdown({
   const [isButtonClicked, setIsButtonClicked] = useState(false);
 
   const [selectedItem, setSelectedItem] = useState<SelectedItem>(defaultValue);
+
+  //URL 변경 시 필터값에 따라 selectedItem 업데이트
+  useEffect(() => {
+    if (Object.keys(filter).length === 0) {
+      setSelectedItem(defaultValue);
+      return;
+    }
+  
+    if (defaultValue === '지역 전체') {
+      setSelectedItem(
+        (filter.location && filterList.includes(filter.location as SelectedItem))
+          ? (filter.location as SelectedItem)
+          : defaultValue
+      );
+    } else if (defaultValue === '최신 순' || defaultValue === '마감 임박') {
+      setSelectedItem(
+        filter.sortBy === 'createdAt' ? '최신 순' :
+        filter.sortBy === 'registrationEnd' ? '마감 임박' :
+        defaultValue
+      );
+    }
+  }, [filter, defaultValue, filterList]);
 
   const convertSortBy = (item: string) => {
     if (item === '최신 순') {

--- a/app/components/common/filter/dropdown.tsx
+++ b/app/components/common/filter/dropdown.tsx
@@ -24,24 +24,26 @@ export function Dropdown({
 
   const [selectedItem, setSelectedItem] = useState<SelectedItem>(defaultValue);
 
-  //URL 변경 시 필터값에 따라 selectedItem 업데이트
   useEffect(() => {
     if (Object.keys(filter).length === 0) {
       setSelectedItem(defaultValue);
       return;
     }
-  
     if (defaultValue === '지역 전체') {
       setSelectedItem(
-        (filter.location && filterList.includes(filter.location as SelectedItem))
+        filter.location && filterList.includes(filter.location as SelectedItem)
           ? (filter.location as SelectedItem)
-          : defaultValue
+          : defaultValue,
       );
-    } else if (defaultValue === '최신 순' || defaultValue === '마감 임박') {
+      return;
+    }
+    if (defaultValue === '최신 순' || defaultValue === '마감 임박') {
+      const sortByMap: Record<string, SelectedItem> = {
+        createdAt: '최신 순',
+        registrationEnd: '마감 임박',
+      };
       setSelectedItem(
-        filter.sortBy === 'createdAt' ? '최신 순' :
-        filter.sortBy === 'registrationEnd' ? '마감 임박' :
-        defaultValue
+        filter.sortBy && sortByMap[filter.sortBy] ? sortByMap[filter.sortBy] : defaultValue,
       );
     }
   }, [filter, defaultValue, filterList]);

--- a/app/components/common/filter/dropdownCalendar.tsx
+++ b/app/components/common/filter/dropdownCalendar.tsx
@@ -23,6 +23,16 @@ export default function DropdownCalendar({
   const [displayDate, setDisplayDate] = useState('');
   const [isReset, setIsReset] = useState(false);
 
+  useEffect(() => {
+    if (!filter.date) {
+      setDisplayDate('');
+      setSelectedDate(startOfToday());
+    } else {
+      setFormattedDate(filter.date);
+      setDisplayDate(filter.date.replaceAll('-', '/').slice(2));
+    }
+  }, [filter.date]);
+
   const handleClickToggleCalendarButton = () => {
     if (isReset) {
       setSelectedDate(startOfToday()); // 초기화 후 다시 버튼을 누르면 오늘 날짜로 설정

--- a/app/hooks/useQueryStringFilter.tsx
+++ b/app/hooks/useQueryStringFilter.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { GetReviewsProps } from '../types/reviews/reviewsApi.types';
-import { checkQueryStringObject } from '../utils/checkQueryStringObjectUtil';
+import {useEffect, useState} from 'react';
+
+import {useRouter, useSearchParams} from 'next/navigation';
+
+import {GetReviewsProps} from '../types/reviews/reviewsApi.types';
+import {checkQueryStringObject} from '../utils/checkQueryStringObjectUtil';
 
 export const useQueryStringFilter = () => {
   const searchParams = useSearchParams();
@@ -13,7 +15,6 @@ export const useQueryStringFilter = () => {
   });
 
   useEffect(() => {
-    //URL에서 현재 쿼리스트링을 가져와서 필터를 최신화
     const queryEntries = Object.fromEntries(searchParams.entries());
 
     const newFilter: GetReviewsProps = checkQueryStringObject({
@@ -22,18 +23,28 @@ export const useQueryStringFilter = () => {
     });
 
     setFilter(newFilter);
-  }, [searchParams]); //searchParams가 변경될 때마다 필터 업데이트
+  }, [searchParams]);
 
   const updateQueryString = (newFilter: Partial<GetReviewsProps>) => {
-    const updatedFilter = { ...filter, ...newFilter };
-    const queryString = new URLSearchParams(updatedFilter as any).toString();
+    const updatedFilter = {...filter, ...newFilter};
+    const queryString = new URLSearchParams(
+      Object.entries(updatedFilter)
+        .filter(([, value]) => value !== undefined && value !== null)
+        .reduce(
+          (acc, [key, value]) => {
+            acc[key] = String(value);
+            return acc;
+          },
+          {} as Record<string, string>,
+        ),
+    ).toString();
     router.replace(`?${queryString}`);
   };
 
   const resetFilter = () => {
-    setFilter({ type: 'DALLAEMFIT' });
+    setFilter({type: 'DALLAEMFIT'});
     router.replace('/');
   };
 
-  return { filter, setFilter, updateQueryString, resetFilter};
+  return {filter, setFilter, updateQueryString, resetFilter};
 };

--- a/app/hooks/useQueryStringFilter.tsx
+++ b/app/hooks/useQueryStringFilter.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import {useEffect, useState} from 'react';
-
-import {useRouter, useSearchParams} from 'next/navigation';
-
-import {GetReviewsProps} from '../types/reviews/reviewsApi.types';
-import {buildQueryParams} from '../utils/buildQueryParamsUtil';
-import {checkQueryStringObject} from '../utils/checkQueryStringObjectUtil';
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { GetReviewsProps } from '../types/reviews/reviewsApi.types';
+import { checkQueryStringObject } from '../utils/checkQueryStringObjectUtil';
 
 export const useQueryStringFilter = () => {
   const searchParams = useSearchParams();
@@ -16,26 +13,27 @@ export const useQueryStringFilter = () => {
   });
 
   useEffect(() => {
-    const deletedEmptyQuery = Object.fromEntries(
-      Array.from(searchParams.entries()).filter(([, value]) => value !== '' && value !== null),
-    );
+    //URL에서 현재 쿼리스트링을 가져와서 필터를 최신화
+    const queryEntries = Object.fromEntries(searchParams.entries());
 
-    const getUrlObject: GetReviewsProps = {
-      ...deletedEmptyQuery,
-      type: (deletedEmptyQuery.type as string) || 'DALLAEMFIT',
-    };
+    const newFilter: GetReviewsProps = checkQueryStringObject({
+      ...queryEntries,
+      type: queryEntries.type || 'DALLAEMFIT', // 기본값 설정
+    });
 
-    const validQueryStringObject = checkQueryStringObject(getUrlObject);
-
-    setFilter(validQueryStringObject);
-  }, []);
+    setFilter(newFilter);
+  }, [searchParams]); //searchParams가 변경될 때마다 필터 업데이트
 
   const updateQueryString = (newFilter: Partial<GetReviewsProps>) => {
-    const updatedFilter = {...filter, ...newFilter};
-    setFilter(updatedFilter);
-    const queryString = buildQueryParams(updatedFilter);
+    const updatedFilter = { ...filter, ...newFilter };
+    const queryString = new URLSearchParams(updatedFilter as any).toString();
     router.replace(`?${queryString}`);
   };
 
-  return {filter, setFilter, updateQueryString};
+  const resetFilter = () => {
+    setFilter({ type: 'DALLAEMFIT' });
+    router.replace('/');
+  };
+
+  return { filter, setFilter, updateQueryString, resetFilter};
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11504,7 +11504,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
       "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
-      "license": "MIT",
       "engines": {
         "node": ">=12.20.0"
       },


### PR DESCRIPTION
## 연관된 이슈
> ex) #SCRUM-13

## 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- useQueryStringFilter에서 filter 상태를 기준으로 동작하도록 변경
- router.replace('/') 실행 시 필터링 UI가 정상적으로 초기화되도록 수정
- Dropdown, DropdownCalendar에서 useEffect로 filter 값 변경 감지하여 UI 동기화
- 모임 생성 요청 중복 실행 방지를 위해 `isSubmitting` 상태 추가
  - 확인 버튼 연속 클릭 시 중복 요청 방지
  - 요청 완료 후 `isSubmitting`을 `false`로 복구하여 정상 동작 유지
## 스크린샷 (선택)
> 작업한 내용에 대한 이미지를 첨부해주세요.

## 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?